### PR TITLE
Fix fetch_results HTTP method; add machine lifecycle controls

### DIFF
--- a/prometheux_chain/__init__.py
+++ b/prometheux_chain/__init__.py
@@ -138,6 +138,9 @@ from .chat_history.manage_chat_history import delete_session
 
 # ── Compute ─────────────────────────────────────────────────────────────────
 from .compute.manage_compute import check_compute_availability
+from .compute.manage_compute import list_machines_combined
+from .compute.manage_compute import set_machine_active
+from .compute.manage_compute import get_machine_status
 
 # ── Vadalog authoring ───────────────────────────────────────────────────────
 from .vadalog.manage_vadalog import analyze_program

--- a/prometheux_chain/client/jarvispy_client.py
+++ b/prometheux_chain/client/jarvispy_client.py
@@ -599,17 +599,20 @@ class JarvisPyClient:
                       scope="user", order_by=None, params=None, compute=None):
         query = {
             'output_predicate': output_predicate,
-            'page': page,
-            'page_size': page_size,
             'project_scope': scope,
         }
+        body = {
+            'page': page,
+            'page_size': page_size,
+        }
         if order_by:
-            query['order_by'] = order_by
+            body['order_by'] = order_by
         if params:
-            query['params'] = json.dumps(params)
+            body['params'] = params
         if compute:
-            query['compute'] = json.dumps(compute)
-        return JarvisPyClient._request("GET", f"/api/v1/concepts/{ontology_id}/fetch", params=query)
+            body['compute'] = compute
+        return JarvisPyClient._request("POST", f"/api/v1/concepts/{ontology_id}/fetch",
+                                       json=body, params=query)
 
     @staticmethod
     def search_results(ontology_id, output_predicate, search_term=None, column_filters=None,
@@ -1100,6 +1103,28 @@ class JarvisPyClient:
             compute['databricks_configs'] = databricks_configs
         return JarvisPyClient._request("POST", "/api/v1/compute/availability",
                                        json={'compute': compute})
+
+    # ── Machines (compute lifecycle) ───────────────────────────────────────
+
+    @staticmethod
+    def list_machines_combined():
+        """Catalog + the caller's enabled/disabled machines."""
+        return JarvisPyClient._request("GET", "/api/v1/machines/machines-combined")
+
+    @staticmethod
+    def set_machine_active(user_machine_id, is_active, autotermination_minutes=None):
+        """Start (is_active=True) or stop (is_active=False) one owned machine."""
+        body = {'user_machine_id': user_machine_id, 'is_active': bool(is_active)}
+        if autotermination_minutes is not None:
+            body['autotermination_minutes'] = autotermination_minutes
+        return JarvisPyClient._request("PATCH", "/api/v1/machines/user-machines/toggle-active",
+                                       json=body)
+
+    @staticmethod
+    def get_machine_status(user_machine_id):
+        """Real-time pod status of one owned machine."""
+        return JarvisPyClient._request(
+            "GET", f"/api/v1/machines/user-machines/{user_machine_id}/status")
 
     # ── Vadalog authoring ─────────────────────────────────────────────────
 

--- a/prometheux_chain/compute/manage_compute.py
+++ b/prometheux_chain/compute/manage_compute.py
@@ -24,3 +24,20 @@ def check_compute_availability(machine_configs=None, databricks_configs=None):
     return JarvisPyClient.check_compute_availability(
         machine_configs=machine_configs, databricks_configs=databricks_configs,
     )
+
+
+def list_machines_combined():
+    """Return the machine catalog plus the caller's enabled/disabled machines."""
+    return JarvisPyClient.list_machines_combined()
+
+
+def set_machine_active(user_machine_id, is_active, autotermination_minutes=None):
+    """Start (is_active=True) or stop (is_active=False) one owned machine."""
+    return JarvisPyClient.set_machine_active(
+        user_machine_id, is_active, autotermination_minutes=autotermination_minutes,
+    )
+
+
+def get_machine_status(user_machine_id):
+    """Return real-time pod status of one owned machine."""
+    return JarvisPyClient.get_machine_status(user_machine_id)


### PR DESCRIPTION
fetch_results used GET, but the backend route
POST /api/v1/concepts/{id}/fetch expects POST with output_predicate/ project_scope as query params and page/page_size/order_by in the body. Switch it to POST (mirrors search_results) so reading concept rows works.

Add machine (compute) lifecycle methods to the client + a manage_compute wrapper, re-exported at the package top level:
- list_machines_combined  -> GET  /api/v1/machines/machines-combined
- set_machine_active      -> PATCH /api/v1/machines/user-machines/toggle-active
- get_machine_status      -> GET  /api/v1/machines/user-machines/{id}/status