### PR TITLE
fix(ontology): capture server id on save + correct export/import routes

### DIFF
--- a/prometheux_chain/client/jarvispy_client.py
+++ b/prometheux_chain/client/jarvispy_client.py
@@ -338,7 +338,7 @@ class JarvisPyClient:
 
     @staticmethod
     def export_ontology(ontology_id, scope="user"):
-        return JarvisPyClient._request("POST", "/api/v1/ontologies/export-project",
+        return JarvisPyClient._request("POST", "/api/v1/ontologies/export-ontology",
                                        json={'project_id': ontology_id, 'scope': scope})
 
     @staticmethod
@@ -346,7 +346,7 @@ class JarvisPyClient:
         payload = {'export_data': export_data, 'scope': scope, 'force_new_id': force_new_id}
         if compute:
             payload['compute'] = compute
-        return JarvisPyClient._request("POST", "/api/v1/ontologies/import-project", json=payload)
+        return JarvisPyClient._request("POST", "/api/v1/ontologies/import-ontology", json=payload)
 
     @staticmethod
     def export_workspace(scope="user"):

--- a/prometheux_chain/ontology/manage_ontologies.py
+++ b/prometheux_chain/ontology/manage_ontologies.py
@@ -22,7 +22,12 @@ def save_ontology(ontology_id=None, ontology_name=None, ontology_scope="user", d
         ontology_id=ontology_id, ontology_name=ontology_name,
         ontology_scope=ontology_scope, description=description,
     ), "save")
-    return data.get('project_id') if isinstance(data, dict) else data
+    # The save endpoint returns the (server-generated on create) id under
+    # 'ontology_id'; older servers used 'project_id'. Read either so a create
+    # never silently yields None (which downstream turns into concepts_None).
+    if isinstance(data, dict):
+        return data.get('ontology_id') or data.get('project_id')
+    return data
 
 
 def list_ontologies(ontology_scopes=None):


### PR DESCRIPTION
## Problem
Building a brand-new ontology through the `px` CLI failed, and left the ontology unusable afterwards. Two independent client/server drifts in this SDK were the cause:

**A — create returned `None`.** `save_ontology` read the new id from `data['project_id']`, but `POST /api/v1/ontologies/save` returns the server-generated id under **`ontology_id`**. So a create yielded `None` → the CLI wrote `id: null` → concept saves hit `INSERT INTO concepts_None` (HTTP 500) and no concepts were created.

**B — export/import 404.** `export_ontology`/`import_ontology` posted to `/ontologies/export-project` and `/import-project`, but those routes were renamed server-side to `/export-ontology` and `/import-ontology`. Every export — and therefore `px plan` / `pull` / re-`apply` — 404'd, even for a cleanly-created ontology.

## Fix
- `save_ontology` reads `data.get('ontology_id') or data.get('project_id')` (fallback keeps older servers working).
- Point `export_ontology`/`import_ontology` at `/export-ontology` / `/import-ontology`.

## Verification
Against the deployed `…/prometheux/mozart` server:
- Probed `POST /ontologies/save` → returns `{"data": {"ontology_id": "<id>"}}`; the wrapper previously returned `None`, now returns the id.
- Clean `px apply` (new ontology + datasource + concept) → creates the ontology with a real id, persists it, saves the concept (no `concepts_None`); follow-up `px plan` → "Local files match server state".
- A previously-broken ontology is now reachable again via `px plan` (export succeeds).

No other route/response-key drift found this pass (save/list/load/copy/snapshots/share all match the current `ontology_router`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)